### PR TITLE
Amend to cover custom location for Oh My Zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Clone `zsh-vi-mode` into your custom plugins repo
 
 ```shell
 git clone https://github.com/jeffreytse/zsh-vi-mode \
-  $HOME/.oh-my-zsh/custom/plugins/zsh-vi-mode
+  $ZSH/custom/plugins/zsh-vi-mode
 ```
 Then load as a plugin in your `.zshrc`
 


### PR DESCRIPTION
Some users, such as myself, have Oh My Zsh installed in a custom location. In either event that the user has it installed in the standard or nonstandard location, the `ZSH` variable points to it.