### PR TITLE
Add note about timeouts in surround guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ option.
 - `sd"`   : Delete `"`
 - `sr"'`  : Change `"` to `'`
 
+Note that key sequences must be pressed in fairly quick succession to avoid a timeout. You may extend this timeout with the [`ZVM_KEYTIMEOUT` option](#readkey-engine).
+  
 #### How to select surround text object?
 
 - `vi"`   : Select the text object inside the quotes


### PR DESCRIPTION
I was pretty confused why `va"` was working fine, but `va(` was not. Turns out I was just too slow typing that parens. Adding a note to spare other slow typists the same confusion.
Also, it would be great if the `b` alias for `(` worked too. I believe this is enabled by default (at least it is in neovim). This lets commands such `vab` behave as `va(`.