### PR TITLE
Fix for tmux cursor shape

### DIFF
--- a/zsh-vi-mode.zsh
+++ b/zsh-vi-mode.zsh
@@ -2993,19 +2993,13 @@ function zvm_viins_undo() {
   fi
 }
 
-# Change cursor to support for inside/outside tmux
 function zvm_set_cursor() {
   # Term of vim isn't supported
   if [[ -n $VIMRUNTIME ]]; then
     return
   fi
 
-  # Tmux sequence
-  if [[ -z $TMUX ]]; then
-    echo -ne "$1"
-  else
-    echo -ne "\ePtmux;\e\e$1\e\\"
-  fi
+  echo -ne "$1"
 }
 
 # Get the escape sequence of cursor style


### PR DESCRIPTION
As mentioned in https://github.com/tmux/tmux/issues/2059#issuecomment-574839532 , no tmux wrapper is needed to support cursor shape changing. Without this fix, the cursor will change back to block style after using nvim and after a status bar update. With this fix, after exitting from nvim the cursor shape will be fine with the default settings.