### PR TITLE
docs: clone plugin into $ZSH_CUSTOM/plugins instead of $ZSH/custom/plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Clone `zsh-vi-mode` into your custom plugins repo
 
 ```shell
 git clone https://github.com/jeffreytse/zsh-vi-mode \
-  $ZSH/custom/plugins/zsh-vi-mode
+  $ZSH_CUSTOM/plugins/zsh-vi-mode
 ```
 Then load as a plugin in your `.zshrc`
 


### PR DESCRIPTION
Use the `$ZSH_CUSTOM` [variable](https://github.com/ohmyzsh/ohmyzsh/wiki/Design#variables-omz-reads) instead of `$ZSH/custom`.