### PR TITLE
docs: Fixes NixOS configuration for initializing `zsh-vi-mode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,20 @@ programs = {
   };
 };
 ```
+  
+Or if you prefer `home-manager`:
+
+```shell
+home-manager.users.[your username] = { pkgs, ... }: {
+  programs = {
+    zsh = {
+      initExtra = ''
+        source ${pkgs.zsh-vi-mode}/share/zsh-vi-mode/zsh-vi-mode.plugin.zsh
+      '';
+    };
+  };
+};
+```
 
 #### Manually
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ For users of Nix, as of [e7e3480530b34a9fe8cb52963ec2cf66e6707e15](https://githu
 ```shell
 programs = {
   zsh = {
-    initExtra = ''
+    interactiveShellInit = ''
       source ${pkgs.zsh-vi-mode}/share/zsh-vi-mode/zsh-vi-mode.plugin.zsh
     '';
   };


### PR DESCRIPTION
`initExtra` is used for home-manager, while `interactiveShellInit` is used for a global zsh config.

https://github.com/nix-community/home-manager/blob/master/modules/programs/zsh.nix#L324-L328
