### PR TITLE
fix syntax highlighting in ZSH 5.9+

### DIFF
--- a/zsh-vi-mode.zsh
+++ b/zsh-vi-mode.zsh
@@ -3261,7 +3261,8 @@ function zvm_init() {
   zvm_define_widget zvm_switch_keyword
 
   # Override standard widgets
-  zvm_define_widget zle-line-pre-redraw zvm_zle-line-pre-redraw
+  autoload add-zle-hook-widget
+  add-zle-hook-widget zle-line-pre-redraw zvm_zle-line-pre-redraw
 
   # Ensure the correct cursor style when an interactive program
   # (e.g. vim, bash, etc.) starts and exits


### PR DESCRIPTION
This fixes the incompatibility between zsh-vi-mode and [zsh-syntax-highlighting ](https://github.com/zsh-users/zsh-syntax-highlighting) on ZSH 5.9+ per this issue https://github.com/zsh-users/zsh-syntax-highlighting/issues/871 

Tagging @danielshahaf for followup