### PR TITLE
Fix for completion display bug with tmux/IntelliJ

### DIFF
--- a/zsh-vi-mode.zsh
+++ b/zsh-vi-mode.zsh
@@ -3153,9 +3153,7 @@ function zvm_zle-line-pre-redraw() {
   if [[ -n $TMUX ]]; then
     zvm_update_cursor
     # Fix display is not updated in the terminal of IntelliJ IDE.
-    # We should update display only when the last widget isn't a
-    # completion widget
-    [[ $LASTWIDGET =~ 'complet' ]] || zle redisplay
+    [[ "$TERMINAL_EMULATOR" == "JetBrains-JediTerm" ]] && zle redisplay
   fi
   zvm_update_highlight
   zvm_update_repeat_commands


### PR DESCRIPTION
IntelliJ terminal requires `zle redisplay` to be called but this breaks
completion menus in non IntelliJ terminals.

This uses an environment variable to detect whether we are in an
IntelliJ terminal and only calls `zle redisplay` for those environments.
See also: https://youtrack.jetbrains.com/issue/IDEA-191464/Add-environment-variable-to-terminal-detect-if-running-in-IntelliJ-IDES

Previously the code tried to guard against this bug by looking at `$LASTWIDGET`
but unfortunately we cannot reliably assume that the completion widget
has `complet` in the name (on my personal setup, I saw
`autosuggest-suggest` and `self-insert` as the `$LASTWIDGET` during
completions depending on context and other zsh plugins enabled).

See also: https://github.com/jeffreytse/zsh-vi-mode/issues/122