### PR TITLE
use absolue path for `rm` for temp file deletion

### DIFF
--- a/zsh-vi-mode.zsh
+++ b/zsh-vi-mode.zsh
@@ -636,7 +636,7 @@ function zvm_escape_non_printed_characters() {
       str="${str}^${c}"
     elif [[ "$c" == '' ]]; then
       str="${str}^?"
-    elif [[ "$c" == ' ' ]]; then
+    elif [[ "$c" == '' ]]; then
       str="${str}^@"
     else
       str="${str}${c}"
@@ -1771,7 +1771,7 @@ function zvm_vi_edit_command_line() {
   # Reload the content to the BUFFER from the temporary
   # file after editing, and delete the temporary file.
   BUFFER=$(cat $tmp_file)
-  rm "$tmp_file"
+  /bin/rm "$tmp_file"
 
   # Exit the visual mode
   case $ZVM_MODE in


### PR DESCRIPTION
I alias `rm` to another command for security reasons (sometimes i delete files by mistake, or i guess some people may just alias it to a move-to-trash command), so it would be better to use the absolute path of rm to ensure deletion of the temp file.