### PR TITLE
feat: integration with clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,6 +801,25 @@ For example:
 ZVM_INIT_MODE=sourcing
 ```
 
+Clipboard Integration
+--------
+
+You can now integrate your clipboard with this plugin by defining the
+`ZVM_CLIP_COPY` and `ZVM_CLIP_PASTE`. These variables determine the
+commands used for clipboard integration.
+
+For example:
+
+```zsh
+# Set the commands for macOS clipboard
+ZVM_CLIP_COPY="pbcopy"
+ZVM_CLIP_PASTE="pbpaste"
+
+# https://github.com/ohmyzsh/ohmyzsh/blob/master/lib/clipboard.zsh
+ZVM_CLIP_COPY="clipcopy"
+ZVM_CLIP_PASTE="clippaste"
+```
+
 ## 💎 Credits
 
 - [Zsh](https://www.zsh.org/) - A powerful shell that operates as both an interactive shell and as a scripting language interpreter.

--- a/zsh-vi-mode.zsh
+++ b/zsh-vi-mode.zsh
@@ -182,6 +182,14 @@
 # ZVM_CURSOR_STYLE_ENABLED
 # enable the cursor style feature (default is true)
 #
+# ZVM_CLIP_COPY
+# the copy command to copy the text to clipboard
+# ZVM_CLIP_PASTE
+# the paste command to paste the text from clipboard
+#
+# For example:
+#   ZVM_CLIP_COPY=clipcopy
+#   ZVM_CLIP_PASTE=clippaste
 
 # Avoid sourcing plugin multiple times
 command -v 'zvm_version' >/dev/null && return
@@ -620,6 +628,20 @@ function zvm_string_to_hex() {
   echo "$str"
 }
 
+# Copy cutbuffer to clipboard if ZVM_CLIP_COPY is set
+function zvm_copy_to_clipboard() {
+  if [[ -n $ZVM_CLIP_COPY ]]; then
+    echo -n "$CUTBUFFER" | $ZVM_CLIP_COPY
+  fi
+}
+
+# Paste cutbuffer from clipboard if ZVM_CLIP_PASTE is set
+function zvm_paste_from_clipboard() {
+  if [[ -n $ZVM_CLIP_PASTE ]]; then
+    CUTBUFFER=$($ZVM_CLIP_PASTE)
+  fi
+}
+
 # Escape non-printed characters
 function zvm_escape_non_printed_characters() {
   local str=
@@ -663,6 +685,7 @@ function zvm_backward_kill_region() {
   CUTBUFFER=${BUFFER:$bpos:$((epos-bpos))}
   BUFFER="${BUFFER:0:$bpos}${BUFFER:$epos}"
   CURSOR=$bpos
+  zvm_copy_to_clipboard
 }
 
 # Remove all characters between the cursor position and the
@@ -685,6 +708,7 @@ function zvm_kill_line() {
   CUTBUFFER=${BUFFER:$bpos:$((epos-bpos))}$'\n'
   BUFFER="${BUFFER:0:$bpos}${BUFFER:$epos}"
   CURSOR=$bpos
+  zvm_copy_to_clipboard
 }
 
 # Remove all characters of the whole line.
@@ -700,6 +724,7 @@ function zvm_kill_whole_line() {
 
   BUFFER="${BUFFER:0:$bpos}${BUFFER:$epos}"
   CURSOR=$cpos
+  zvm_copy_to_clipboard
 }
 
 # Exchange the point and mark
@@ -1018,6 +1043,7 @@ function zvm_yank() {
     CUTBUFFER=${CUTBUFFER}$'\n'
   fi
   CURSOR=$bpos MARK=$epos
+  zvm_copy_to_clipboard
 }
 
 # Up case of the visual selection
@@ -1062,6 +1088,7 @@ function zvm_vi_yank() {
 
 # Put cutbuffer after the cursor
 function zvm_vi_put_after() {
+  zvm_paste_from_clipboard
   local head= foot=
   local content=${CUTBUFFER}
   local offset=1
@@ -1114,6 +1141,7 @@ function zvm_vi_put_after() {
 
 # Put cutbuffer before the cursor
 function zvm_vi_put_before() {
+  zvm_paste_from_clipboard
   local head= foot=
   local content=${CUTBUFFER}
 
@@ -1178,10 +1206,12 @@ function zvm_replace_selection() {
 
   BUFFER="${BUFFER:0:$bpos}${cutbuf}${BUFFER:$epos}"
   CURSOR=$cpos
+  zvm_copy_to_clipboard
 }
 
 # Replace characters of the visual selection
 function zvm_vi_replace_selection() {
+  zvm_paste_from_clipboard
   zvm_replace_selection $CUTBUFFER
   zvm_exit_visual_mode ${1:-true}
 }
@@ -1233,6 +1263,7 @@ function zvm_vi_change() {
 
   zvm_exit_visual_mode false
   zvm_select_vi_mode $ZVM_MODE_INSERT
+  zvm_copy_to_clipboard
 }
 
 # Change characters from cursor to the end of current line
@@ -1251,6 +1282,7 @@ function zvm_vi_change_eol() {
 
   zvm_reset_repeat_commands $ZVM_MODE c 0 $#CUTBUFFER
   zvm_select_vi_mode $ZVM_MODE_INSERT
+  zvm_copy_to_clipboard
 }
 
 # Default handler for unhandled key events
@@ -2062,6 +2094,7 @@ function zvm_change_surround_text_object() {
       CURSOR=$bpos
       ;;
   esac
+  zvm_copy_to_clipboard
 }
 
 # Repeat last change


### PR DESCRIPTION
This is a simple and common implementation for integrating with the clipboard, allowing users to define the `ZVM_CLIP_COPY` and `ZVM_CLIP_PASTE` environment variables to determine what command to use for clipboard integration. 

Essentially, it assigns the result of executing `ZVM_CLIP_PASTE` to the `CUTBUFFER` variable before reading the `CUTBUFFER` function, and sends the `CUTBUFFER` through a pipeline to `ZVM_CLIP_COPY` after writing the `CUTBUFFER` function. It is also very easy to use with https://github.com/ohmyzsh/ohmyzsh/blob/master/lib/clipboard.zsh.