### PR TITLE
add support for foot terminal

### DIFF
--- a/zsh-vi-mode.zsh
+++ b/zsh-vi-mode.zsh
@@ -3135,9 +3135,9 @@ function zvm_cursor_style() {
   case $term in
     # For xterm and rxvt and their derivatives use the same escape
     # sequences as the VT520 terminal. And screen, konsole, alacritty
-    # and st implement a superset of VT100 and VT100, they support
+    # st and foot implement a superset of VT100 and VT100, they support
     # 256 colors the same way xterm does.
-    xterm*|rxvt*|screen*|tmux*|konsole*|alacritty*|st*)
+    xterm*|rxvt*|screen*|tmux*|konsole*|alacritty*|st*|foot*)
       case $style in
         $ZVM_CURSOR_BLOCK) style='\e[2 q';;
         $ZVM_CURSOR_UNDERLINE) style='\e[4 q';;

--- a/zsh-vi-mode.zsh
+++ b/zsh-vi-mode.zsh
@@ -3134,7 +3134,7 @@ function zvm_cursor_style() {
 
   case $term in
     # For xterm and rxvt and their derivatives use the same escape
-    # sequences as the VT520 terminal. And screen, konsole, alacritty
+    # sequences as the VT520 terminal. And screen, konsole, alacritty,
     # st and foot implement a superset of VT100 and VT100, they support
     # 256 colors the same way xterm does.
     xterm*|rxvt*|screen*|tmux*|konsole*|alacritty*|st*|foot*)


### PR DESCRIPTION
Fixes #130.
`foot` implements vt100 and supports 256 colors, so simply adding it to the supported terminals should work. I have been using it for a long time with the workaround `ZVM_TERM=xterm-256color`, until recently when I had a chance to delve into the code and come up with this simple solution.