### PR TITLE
Fix: update documentation to include parameter substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Clone `zsh-vi-mode` into your custom plugins repo
 
 ```shell
 git clone https://github.com/jeffreytse/zsh-vi-mode \
-  $ZSH_CUSTOM/plugins/zsh-vi-mode
+  ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-vi-mode
 ```
 Then load as a plugin in your `.zshrc`
 


### PR DESCRIPTION
The documentation for installation using oh-my-zsh does not include a default value for the custom plugin folder.
Thus, if the `$ZSH_CUSTOM` variable is not set it tries to install the plugin inside `/plugins/zsh-vi-mode` which is clearly an error.