### PR TITLE
Fix: Failed to compile regex: trailing backslash (\) in Termux

### DIFF
--- a/zsh-vi-mode.zsh
+++ b/zsh-vi-mode.zsh
@@ -3219,7 +3219,7 @@ function zvm_cursor_style() {
       $ZVM_MODE_OPPEND) old_style=$ZVM_OPPEND_MODE_CURSOR;;
     esac
 
-    if [[ $old_style =~ '\\e\\][0-9]+;.+\\a' ]]; then
+    if [[ $old_style =~ '\\e\][0-9]+;.+\\a' ]]; then
       style=$style'\e\e]112\a'
     fi
   fi

--- a/zsh-vi-mode.zsh
+++ b/zsh-vi-mode.zsh
@@ -3219,7 +3219,7 @@ function zvm_cursor_style() {
       $ZVM_MODE_OPPEND) old_style=$ZVM_OPPEND_MODE_CURSOR;;
     esac
 
-    if [[ $old_style =~ '\e\][0-9]+;.+\a' ]]; then
+    if [[ $old_style =~ '\\e\\][0-9]+;.+\\a' ]]; then
       style=$style'\e\e]112\a'
     fi
   fi


### PR DESCRIPTION
On Android 14, an error occurs upon entering a command in termux while using this plugin. The contained changes fix that issue while not creating addt'l issues on main debian machine.