### PR TITLE
docs: fix instructions for nix home-manager built-in "plugin" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,8 +249,8 @@ home-manager.users.[your username] = { pkgs, ... }: {
           name = "vi-mode";
           src = pkgs.zsh-vi-mode;
           file = "share/zsh-vi-mode/zsh-vi-mode.plugin.zsh";
-        };
-      ]
+        }
+      ];
     };
   };
 };


### PR DESCRIPTION
nix list items are not separated by any symbol, however a statement must always end with a semicolon.