### PR TITLE
adding support for changing cursor in GNU screen

### DIFF
--- a/zsh-vi-mode.zsh
+++ b/zsh-vi-mode.zsh
@@ -3224,6 +3224,11 @@ function zvm_cursor_style() {
     fi
   fi
 
+  # in GNU screen, we need to surround an escape sequence by '\eP' and '\e\\'
+  if [[ $term =~ "^screen.*" ]]; then
+    style='\eP'"$style"'\e\\'
+  fi
+
   echo $style
 }
 


### PR DESCRIPTION
Hi,

The purpose of this pull request is to allow zsh-vi-mode to change the cursor in the GNU screen.

The only change is wrapping the cursor style command in '\eP' '\e\\' as detailed here:
* https://web.archive.org/web/20220411223346/https://ttssh2.osdn.jp/manual/4/en/usage/tips/vim.html#withScreen
* https://github.com/neovim/neovim/issues/17031