### PR TITLE
Small change to fix `case` parse error

### DIFF
--- a/zsh-vi-mode.zsh
+++ b/zsh-vi-mode.zsh
@@ -1996,7 +1996,9 @@ function zvm_match_surround() {
     ']') bchar='[';echar=']';;
     '}') bchar='{';echar='}';;
     '>') bchar='<';echar='>';;
-    \'|\"|\`| ) ;;
+    "'") ;;
+    '"') ;;
+    '`') ;;
     *) return;;
   esac
   echo $bchar $echar


### PR DESCRIPTION
Small change to fix parse error in `case` statement.

For some reason, I get the following error with the current code:
```text
/home/rdeleulopesp/dotfiles/extra/plugins/zsh/zsh-vi-mode/zsh-vi-mode.zsh:1999: parse error near `)'
```

My zsh version is:
```text
zsh 5.4.1 (x86_64-unknown-linux-gnu)
```

Perhaps the syntax with `|` is not portable to all versions? I believe this change would not affect functionality, and it fixes the error for me.

Let me know if additional information is needed.