### PR TITLE
fix: resolve stupid performance issue in `zvm_exist_command`

### DIFF
--- a/zsh-vi-mode.zsh
+++ b/zsh-vi-mode.zsh
@@ -3617,7 +3617,7 @@ function zvm_init() {
 
 # Check if a command is existed
 function zvm_exist_command() {
-  command -v "$1" >/dev/null
+  (($+commands[$1] + $+functions[$1]))
 }
 
 # Execute commands


### PR DESCRIPTION
I believe the following two images clearly illustrate the issue.
`zvm_exist_command` can be easily implemented using only the built-in syntax of zsh. The current implementation is an utterly shameful waste of performance.
![image](https://github.com/user-attachments/assets/ca30e00e-f898-4b44-a022-ed35d1ce608f)
![image](https://github.com/user-attachments/assets/203c7857-14bf-4366-b022-f29a66f2d646)
