### PR TITLE
feat: make `vv` temporary file a `.zsh` file

### DIFF
--- a/zsh-vi-mode.zsh
+++ b/zsh-vi-mode.zsh
@@ -1888,7 +1888,7 @@ function zvm_repeat_command {
 # Edit command line in EDITOR
 function zvm_vi_edit_command_line() {
   # Create a temporary file and save the BUFFER to it
-  local tmp_file=$(mktemp ${ZVM_TMPDIR}/zshXXXXXX)
+  local tmp_file=$(mktemp ${ZVM_TMPDIR}/zshXXXXXX.zsh)
 
   # Some users may config the noclobber option to prevent from
   # overwriting existing files with the > operator, we should


### PR DESCRIPTION
Improves highlighting for editors. Specifically helpful for Helix, which doesn't have a modeline yet.