### PR TITLE
Fix regex for zsh without PCRE support

### DIFF
--- a/zsh-vi-mode.zsh
+++ b/zsh-vi-mode.zsh
@@ -3221,7 +3221,7 @@ function zvm_cursor_style() {
       $ZVM_MODE_OPPEND) old_style=$ZVM_OPPEND_MODE_CURSOR;;
     esac
 
-    if [[ $old_style =~ '\e\][0-9]+;.+\a' ]]; then
+    if [[ $old_style =~ "\\\e\][0-9]+;.+\\\a" ]]; then
       style=$style'\e\e]112\a'
     fi
   fi


### PR DESCRIPTION
Fixes #159.

I use zsh-vi-mode on FreeBSD and do not wish to install zsh from ports because of this small issue. I do not quite understand these three lines - `112` does not look like a valid OSC sequence to me as I cannot find it in [xterm docs](https://www.man7.org/linux/man-pages/man4/console_codes.4.html). Commenting these lines out also does not seem to affect the cursor style. Did I miss something?

But this patch should fix the error without changing whatever the original behavior is.