### PR TITLE
fix(zvm_vi_edit_command_line): Always use unaliased version of cat

### DIFF
--- a/zsh-vi-mode.zsh
+++ b/zsh-vi-mode.zsh
@@ -1903,7 +1903,7 @@ function zvm_vi_edit_command_line() {
 
   # Reload the content to the BUFFER from the temporary
   # file after editing, and delete the temporary file.
-  BUFFER=$(cat $tmp_file)
+  BUFFER=$(\cat $tmp_file)
   rm "$tmp_file"
 
   # Exit the visual mode


### PR DESCRIPTION
Use the unaliased version of cat (always the 'cat' binary). Fixes instances where the user has a global alias to another program (i.e. 'bat').

Behavior fixed: 
* Go into normal mode with [ESC]
* Press the keys [v v]
* <Enters the $VISUAL editor, in my case lvim with a temporary buffer>
* <Type something and :wq, saving and quitting the buffer>

And then:
![image](https://github.com/user-attachments/assets/84e86fce-efaa-4301-a11c-e127e5a62626) 

On the terminal on top, I have `BUFFER=$(cat $tmp_file)`, so it swaps cat for bat and outputs into the prompt the output of bat.

On the terminal on the bottom, I have `BUFFER=$(\cat $tmp_file)`, so it always uses 'cat' despite my global alias to bat.
