### PR TITLE
fix: cursor style compatibility with custom VIMRUNTIME variable

### DIFF
--- a/zsh-vi-mode.zsh
+++ b/zsh-vi-mode.zsh
@@ -3180,7 +3180,7 @@ function zvm_viins_undo() {
 
 function zvm_set_cursor() {
   # Term of vim isn't supported
-  if [[ -n $VIMRUNTIME ]]; then
+  if [[ -n $VIM ]]; then
     return
   fi
 


### PR DESCRIPTION
I need to load runtime scripts from a custom path using the VIMRUNTIME environment variable. However, this causes zsh-vi-mode to mistakenly think I'm inside Vim's built-in terminal, which leads to the loss of my cursor style.

Inside Vim’s actual built-in terminal, the VIM environment variable set. This VIM variable doesn't affect how Vim behaves on startup and is unlikely to be intentionally set by users. Therefore, adding a check for this VIM variable would prevent zsh-vi-mode from making this incorrect assumption and fix my cursor issue.