### PR TITLE
Don't set KEYTIMEOUT to be 1

### DIFF
--- a/zsh-vi-mode.zsh
+++ b/zsh-vi-mode.zsh
@@ -3388,13 +3388,6 @@ function zvm_init() {
       ;;
   esac
 
-  # Reduce ESC delay (zle default is 0.4 seconds)
-  # Set to 0.01 second delay for taking over the key input processing
-  case $ZVM_READKEY_ENGINE in
-    $ZVM_READKEY_ENGINE_NEX) KEYTIMEOUT=1;;
-    $ZVM_READKEY_ENGINE_ZLE) KEYTIMEOUT=$(($ZVM_KEYTIMEOUT*100));;
-  esac
-
   # Create User-defined widgets
   zvm_define_widget zvm_default_handler
   zvm_define_widget zvm_readkeys_handler


### PR DESCRIPTION
I've been having issues when trying to use this plugin with [fzf-git](https://github.com/junegunn/fzf-git.sh). Funnily enough, simply removing these lines which set the zsh KEYTIMEOUT to be 1 seems to not affect the performace or the delay and allows fzf-git.sh to work!