### PR TITLE
fix: visual mode highlight lingers after put

### DIFF
--- a/zsh-vi-mode.zsh
+++ b/zsh-vi-mode.zsh
@@ -1152,7 +1152,6 @@ function zvm_vi_put_after() {
   local count=${NUMERIC:-1}
   local head= foot=
   local content=${CUTBUFFER}
-  local offset=1
 
   if [[ ${content: -1} == $'\n' ]]; then
     local pos=${CURSOR}
@@ -1183,7 +1182,6 @@ function zvm_vi_put_after() {
       repeated+="$content"
     done
 
-    offset=0
     BUFFER="${head}${repeated}${foot}"
     CURSOR=$pos
   else
@@ -1207,9 +1205,8 @@ function zvm_vi_put_after() {
     CURSOR=$CURSOR+$#repeated
   fi
 
-  # Refresh display and highlight buffer
+  # Refresh display
   zvm_highlight clear
-  zvm_highlight custom $(($#head+$offset)) $(($#head+$#repeated+$offset))
 }
 
 # Put cutbuffer before the cursor
@@ -1260,9 +1257,8 @@ function zvm_vi_put_before() {
     CURSOR=$((CURSOR-1))
   fi
 
-  # Refresh display and highlight buffer
+  # Refresh display
   zvm_highlight clear
-  zvm_highlight custom $#head $(($#head+$#repeated))
 }
 
 # Replace a selection


### PR DESCRIPTION
### Problem

The highlight set after a normal mode `p` or `P` lingers. Current `master` behavior:

https://github.com/user-attachments/assets/66f04597-0761-44d4-a7c6-497a5e85c93f

### Solution

Do not highlight text put with `p` or `P` (changes in `zvm_vi_put_after` and `zvm_vi_put_before`).

Personally, I don't use highlights for yank/put, so I'm happy with this solution. Nonetheless, I understand if this removal is not desired, I listed alternative solutions below. Let me know if you want me to rework the solution. Behavior from this branch:

https://github.com/user-attachments/assets/eae4d983-022b-4c68-9fc7-6b282d72a112

### Alternative solutions

1. Highlight on put but clear on cursor move, like <kbd>ctrl+y</kbd> on `bindkey -e` (emacs) or <kbd>p</kbd>/<kbd>P</kbd> on `bindkey -v` (vi).
2. Highlight on put but with a timer, like [yanky.nvim](https://github.com/gbprod/yanky.nvim). Perhaps not possible in a zsh plugin.

The alternative solution 1 seems more correct than the solution of this branch, as it would make ZVM match the behavior of `bindkey -v` insofar highlights, but the cost would be (likely) scattering `zvm_highlight clear` on every place where the cursor can be moved.

### Notes

Related: #329

The videos were recorded using [vhs](https://github.com/charmbracelet/vhs) with this tape file so the inputs are exactly the same on both tests:

<details>

<summary><code>hl-lingers-after-put.tape</code></summary>

```shell
Output hl-lingers-after-put.mp4

Set TypingSpeed 0.5s
Set Shell zsh

Hide
Type@5ms "curl -L raw.githubusercontent.com/jeffreytse/zsh-vi-mode/refs/heads/master/zsh-vi-mode.zsh | source /dev/stdin && clear"
# Type@5ms "curl -L raw.githubusercontent.com/hernancerm/zsh-vi-mode/refs/heads/fix-hl-lingers-after-put/zsh-vi-mode.zsh | source /dev/stdin && clear"
Enter
Sleep 0.2s
Show

# Single hihglight lingers

Sleep 0.5s
Type@0.2s "echo foo"
Ctrl+[
Sleep 0.5s
Type "yiwpibar"
Ctrl+[
Sleep 0.5s
Type "A"
Sleep 0.5s
Backspace 3
Enter

# Multiple hihglights linger

Sleep 0.2s
Type@0.2s "foo bar"
Ctrl+[
Sleep 0.5s
Type "yiwpio"
Ctrl+[
Sleep 0.5s
Type "0yiwPio"
Ctrl+[
Sleep 0.5s
Type "A baz"
Ctrl+[
Sleep 0.5s
Type "yiwpio"
Ctrl+[
Sleep 0.5s
Type@0.2s "Iecho "
Enter

Sleep 0.5s
```

</details>

Thanks for the plugin!