### PR TITLE
fix: visual mode delay on y

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,6 @@ option.
 1. `classic` mode (verb->s->surround)
 
 - `S"`    : Add `"` for visual selection
-- `ys"`   : Add `"` for visual selection
 - `cs"'`  : Change `"` to `'`
 - `ds"`   : Delete `"`
 

--- a/zsh-vi-mode.zsh
+++ b/zsh-vi-mode.zsh
@@ -86,7 +86,6 @@
 #
 # 1. 'classic' mode (verb->s->surround):
 #   S"    Add " for visual selection
-#   ys"   Add " for visual selection
 #   cs"'  Change " to '
 #   ds"   Delete "
 #
@@ -2161,7 +2160,6 @@ function zvm_parse_surround_keys() {
   case "${keys}" in
     vS*) action=S; surround=${keys:2};;
     vsa*) action=a; surround=${keys:3};;
-    vys*) action=y; surround=${keys:3};;
     s[dr]*) action=${keys:1:1}; surround=${keys:2};;
     [acd]s*) action=${keys:0:1}; surround=${keys:2};;
     [cdvy][ia]*) action=${keys:0:2}; surround=${keys:2};;
@@ -3915,7 +3913,7 @@ function zvm_init() {
       for c in {d,c}s${s}; do
         zvm_bindkey vicmd "$c" zvm_change_surround
       done
-      for c in {S,ys}${s}; do
+      for c in S${s}; do
         zvm_bindkey visual "$c" zvm_change_surround
       done
     fi


### PR DESCRIPTION
### Problem

When `ZVM_VI_SURROUND_BINDKEY=classic` (default) and in visual mode, `y` has a delay of `ZVM_KEYTIMEOUT` before it yanks. In the video I set the timeout to 1.4 seconds to make the delay easier to notice. In my experience, this delay is noticeable during the actual usage of the plugin even when the timeout has the default value of 0.4 seconds.

https://github.com/user-attachments/assets/48ec5c9c-1ea3-4575-a5bc-fee38c307a8d

### Solution

Remove the visual mode classic-mode-surround keybind `ys<surround>`.

The visual mode `ys<surround>` keybind causes the delay since there are two visual mode keybinds that start with `y`: `y` itself and `ys<surround>`. By removing the latter then `y` can be resolved immediately. I've reviewed [vim-surround](https://github.com/tpope/vim-surround) and there is no `ys<surround>` visual mode keymap, so I think that removing this keybind is sensible (although it can be considered a breaking change). No change when `ZVM_VI_SURROUND_BINDKEY=s-prefix`. Behavior from this branch:

https://github.com/user-attachments/assets/5b996a3b-b375-4fd7-acc4-3eb5b9ae222b

### Notes

The videos were recorded using [vhs](https://github.com/charmbracelet/vhs) (from this [PR](https://github.com/charmbracelet/vhs/pull/719)) with this tape file so the inputs are exactly the same on both tests:

<details>

<summary><code>vis-mode-delay-on-y.tape</code></summary>

```shell
Output vis-mode-delay-on-y.mp4

Set TypingSpeed 0.5s
Set CaptionFontSize 26
Set CaptionInactivityTimer 500ms
Set CaptionAlignment "bottom-left"
Set CaptionKeyStyle "vim"
Set Width 840
Set Height 300
Set Shell zsh

Hide
Type@5ms "curl -L raw.githubusercontent.com/jeffreytse/zsh-vi-mode/refs/heads/master/zsh-vi-mode.zsh | source /dev/stdin && clear"
#Type@5ms "curl -L raw.githubusercontent.com/hernancerm/zsh-vi-mode/refs/heads/fix-vis-mode-delay-on-y/zsh-vi-mode.zsh | source /dev/stdin && clear"
Enter
Sleep 0.2s
Show

CaptionOn

Type@0.1s "ZVM_KEYTIMEOUT=1.4"
Enter

Sleep 0.5s
Type@0.2s "foo"
Ctrl+[
Sleep 0.5s
Type "vb"
Sleep 1s
Type "y"
Sleep 2s
```

</details>

Thanks for the plugin!